### PR TITLE
feat(movimientos/productos): persistencia CRUD productos + notificaciones WebSocket y validación de movimientos

### DIFF
--- a/.rest-client.env.json
+++ b/.rest-client.env.json
@@ -1,0 +1,6 @@
+{
+  "Local": {
+    "host": "http://localhost:8080",
+    "token": ""
+  }
+}

--- a/requests.http
+++ b/requests.http
@@ -1,0 +1,128 @@
+# Variables
+@host = http://localhost:8080
+
+### 1) Registro de usuario (ADMIN necesario para endpoints /api/usuarios; aquí creamos un usuario)
+POST {{host}}/api/auth/registro
+Content-Type: application/json
+
+{
+  "nombreUsuario": "admin1",
+  "password": "contrasenaSegura123",
+  "roles": ["ADMIN"]
+}
+
+### 2) Login -> devuelve token
+POST {{host}}/api/auth/login
+Content-Type: application/json
+
+{
+  "nombreUsuario": "admin1",
+  "password": "contrasenaSegura123"
+}
+
+### 3) Example: usar token (replace {{token}} with the value from login response)
+# Get products (roles: ADMIN,SUPERVISOR,OPERADOR)
+GET {{host}}/api/productos
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjEiLCJleHAiOjE3NTk1MzYzNzUsImlhdCI6MTc1OTUyOTE3NSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdfQ.6zBq4pXi-rCltXlstjVDnyMNZvyD1Gsj_FAGh9WOP24
+
+
+### 4) Crear producto (roles: ADMIN,SUPERVISOR)
+POST {{host}}/api/productos
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjEiLCJleHAiOjE3NTk1MzYzNzUsImlhdCI6MTc1OTUyOTE3NSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdfQ.6zBq4pXi-rCltXlstjVDnyMNZvyD1Gsj_FAGh9WOP24
+
+{
+  "nombre": "Pc de mesa",
+  "stock": 20
+}
+
+### 5) Actualizar producto (roles: ADMIN,SUPERVISOR)
+PUT {{host}}/api/productos/p1
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjEiLCJleHAiOjE3NTk1MzYzNzUsImlhdCI6MTc1OTUyOTE3NSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdfQ.6zBq4pXi-rCltXlstjVDnyMNZvyD1Gsj_FAGh9WOP24
+
+{
+  "nombre": "Teclado mecánico si",
+  "stock": 15
+}
+
+### 6) Eliminar producto (roles: ADMIN)
+DELETE {{host}}/api/productos/68e04ab38559c30c8c6bed68
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjEiLCJleHAiOjE3NTk1MzYzNzUsImlhdCI6MTc1OTUyOTE3NSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdfQ.6zBq4pXi-rCltXlstjVDnyMNZvyD1Gsj_FAGh9WOP24
+
+
+### 7) Crear movimiento (roles: SUPERVISOR,OPERADOR) - SALIDA (ejemplo)
+POST {{host}}/api/movimientos
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjEiLCJleHAiOjE3NTk1MzYzNzUsImlhdCI6MTc1OTUyOTE3NSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdfQ.6zBq4pXi-rCltXlstjVDnyMNZvyD1Gsj_FAGh9WOP24
+
+{
+  "productoId": "68e04b9a8559c30c8c6bed69",
+  "cantidad": 5,
+  "tipo": "SALIDA"
+}
+
+### 7.1) Crear movimiento - ENTRADA (ejemplo)
+POST {{host}}/api/movimientos
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "productoId": "68e05624de9f1c41d5079c89",
+  "cantidad": 10,
+  "tipo": "ENTRADA"
+}
+
+### 7.2) Crear movimiento - sin token (debe devolver 401 si la seguridad está activa)
+POST {{host}}/api/movimientos
+Content-Type: application/json
+
+{
+  "productoId": "68e04b9a8559c30c8c6bed69",
+  "cantidad": 2,
+  "tipo": "SALIDA"
+}
+
+### 7.3) Crear movimiento - payload inválido (ej: cantidad no numérica) => espera 400 o manejo de error
+POST {{host}}/api/movimientos
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "productoId": "68e04b9a8559c30c8c6bed69",
+  "cantidad": "cinco",
+  "tipo": "SALIDA"
+}
+
+### 7.4) Ejemplo curl (usa la variable TOKEN desde tu shell)
+# Obtener TOKEN (ejemplo, si no usas jq copia el token manualmente):
+# TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login -H "Content-Type: application/json" -d '{"nombreUsuario":"operador1","password":"operadorPass123"}' | jq -r '.token')
+
+# Crear movimiento con curl
+curl -X POST {{host}}/api/movimientos \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"productoId":"p1","cantidad":5,"tipo":"SALIDA"}' -v
+
+### 8) Endpoints de usuarios (roles: ADMIN)
+# Crear usuario via /api/usuarios
+POST {{host}}/api/usuarios
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "nombreUsuario": "operador1",
+  "password": "operadorPass123",
+  "roles": ["OPERADOR"]
+}
+
+# Listar usuarios
+GET {{host}}/api/usuarios
+Authorization: Bearer {{token}}
+
+
+### Notas:
+# - Usa el bloque 2 (login) para obtener el token y pégalo donde pone {{token}} (sin comillas).
+# - Para VS Code: instala la extensión "REST Client" y haz clic en "Send Request" sobre cada bloque.
+# - Si prefieres curl, después de obtener el token ejecuta:
+#   curl -H "Authorization: Bearer <token>" {{host}}/api/productos

--- a/src/main/java/Control_inventario/control_inventario/config/WebSocketConfig.java
+++ b/src/main/java/Control_inventario/control_inventario/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package Control_inventario.control_inventario.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/java/Control_inventario/control_inventario/controlador/MovimientoControlador.java
+++ b/src/main/java/Control_inventario/control_inventario/controlador/MovimientoControlador.java
@@ -1,16 +1,36 @@
 package Control_inventario.control_inventario.controlador;
+
+import Control_inventario.control_inventario.dto.MovimientoNotification;
+import Control_inventario.control_inventario.dto.MovimientoReq;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/movimientos")
 public class MovimientoControlador {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public MovimientoControlador(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
     @PostMapping
-    @PreAuthorize("hasAnyRole('SUPERVISOR','OPERADOR')")
-    public Map<String, Object> crear(@RequestBody Map<String, Object> body) {
-        body.put("registrado", true);
-        return body;
+    @PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR','OPERADOR')")
+    public Map<String, Object> crear(@RequestBody @jakarta.validation.Valid MovimientoReq req, Principal principal) {
+        // Build and send notification to websocket subscribers
+        MovimientoNotification notif = new MovimientoNotification(req.productoId(), req.cantidad(), req.tipo(), principal != null ? principal.getName() : null);
+        messagingTemplate.convertAndSend("/topic/movimientos", notif);
+
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        resp.put("productoId", req.productoId());
+        resp.put("cantidad", req.cantidad());
+        resp.put("tipo", req.tipo());
+        resp.put("registrado", true);
+        return resp;
     }
 }

--- a/src/main/java/Control_inventario/control_inventario/controlador/ProductoControlador.java
+++ b/src/main/java/Control_inventario/control_inventario/controlador/ProductoControlador.java
@@ -1,43 +1,50 @@
 package Control_inventario.control_inventario.controlador;
+
+import Control_inventario.control_inventario.entidad.Producto;
+import Control_inventario.control_inventario.servicio.ProductoServicio;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/productos")
 public class ProductoControlador {
-    @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR','OPERADOR')")
-    public List<Map<String, Object>> listar() {
-        return List.of(
-                Map.of("id", "p1", "nombre", "Laptop", "stock", 12),
-                Map.of("id", "p2", "nombre", "Mouse", "stock", 55)
-        );
+
+    private final ProductoServicio servicio;
+
+    public ProductoControlador(ProductoServicio servicio) {
+        this.servicio = servicio;
     }
 
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR','OPERADOR')")
+    public List<Producto> listar() {
+        return servicio.listar();
+    }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR')")
-    public Map<String, Object> crear(@RequestBody Map<String, Object> body) {
-        body.put("id", "nuevo-id");
-        return body;
+    public ResponseEntity<Producto> crear(@RequestBody Producto body) {
+        Producto creado = servicio.crear(body);
+        return ResponseEntity.created(URI.create("/api/productos/" + creado.getId())).body(creado);
     }
-
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR')")
-    public Map<String, Object> actualizar(@PathVariable String id, @RequestBody Map<String, Object> body) {
-        body.put("id", id);
-        body.put("actualizado", true);
-        return body;
+    public ResponseEntity<Producto> actualizar(@PathVariable String id, @RequestBody Producto body) {
+        return servicio.actualizar(id, body)
+                .map(p -> ResponseEntity.ok(p))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
-
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
-    public Map<String, Object> eliminar(@PathVariable String id) {
-        return Map.of("id", id, "eliminado", true);
+    public ResponseEntity<?> eliminar(@PathVariable String id) {
+        boolean ok = servicio.eliminar(id);
+        if (ok) return ResponseEntity.ok().body(java.util.Map.of("id", id, "eliminado", true));
+        return ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/Control_inventario/control_inventario/dto/MovimientoNotification.java
+++ b/src/main/java/Control_inventario/control_inventario/dto/MovimientoNotification.java
@@ -1,0 +1,9 @@
+package Control_inventario.control_inventario.dto;
+
+public record MovimientoNotification(
+        String productoId,
+        Integer cantidad,
+        String tipo,
+        String usuario
+) {
+}

--- a/src/main/java/Control_inventario/control_inventario/dto/MovimientoReq.java
+++ b/src/main/java/Control_inventario/control_inventario/dto/MovimientoReq.java
@@ -1,0 +1,12 @@
+package Control_inventario.control_inventario.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MovimientoReq(
+        @NotBlank String productoId,
+        @NotNull @Min(1) Integer cantidad,
+        @NotBlank String tipo
+) {
+}

--- a/src/main/java/Control_inventario/control_inventario/entidad/Producto.java
+++ b/src/main/java/Control_inventario/control_inventario/entidad/Producto.java
@@ -1,0 +1,33 @@
+package Control_inventario.control_inventario.entidad;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("productos")
+public class Producto {
+
+    @Id
+    private String id;
+
+    @NotBlank
+    private String nombre;
+
+    private Integer stock;
+
+    public Producto() {}
+
+    public Producto(String nombre, Integer stock) {
+        this.nombre = nombre;
+        this.stock = stock;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+
+    public Integer getStock() { return stock; }
+    public void setStock(Integer stock) { this.stock = stock; }
+}

--- a/src/main/java/Control_inventario/control_inventario/repositorio/ProductoRepositorio.java
+++ b/src/main/java/Control_inventario/control_inventario/repositorio/ProductoRepositorio.java
@@ -1,0 +1,7 @@
+package Control_inventario.control_inventario.repositorio;
+
+import Control_inventario.control_inventario.entidad.Producto;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ProductoRepositorio extends MongoRepository<Producto, String> {
+}

--- a/src/main/java/Control_inventario/control_inventario/seguridad/SecurityConfig.java
+++ b/src/main/java/Control_inventario/control_inventario/seguridad/SecurityConfig.java
@@ -27,10 +27,10 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/actuator/health").permitAll()
-                        .anyRequest().authenticated()
-                )
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/auth/**", "/actuator/health", "/ws/**", "/sockjs/**").permitAll()
+            .anyRequest().authenticated()
+        )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/Control_inventario/control_inventario/servicio/ProductoServicio.java
+++ b/src/main/java/Control_inventario/control_inventario/servicio/ProductoServicio.java
@@ -1,0 +1,46 @@
+package Control_inventario.control_inventario.servicio;
+
+import Control_inventario.control_inventario.entidad.Producto;
+import Control_inventario.control_inventario.repositorio.ProductoRepositorio;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProductoServicio {
+
+    private final ProductoRepositorio repo;
+
+    public ProductoServicio(ProductoRepositorio repo) {
+        this.repo = repo;
+    }
+
+    public List<Producto> listar() {
+        return repo.findAll();
+    }
+
+    public Producto crear(Producto p) {
+        return repo.save(p);
+    }
+
+    public Optional<Producto> buscarPorId(String id) {
+        return repo.findById(id);
+    }
+
+    public Optional<Producto> actualizar(String id, Producto cambios) {
+        return repo.findById(id).map(existing -> {
+            if (cambios.getNombre() != null) existing.setNombre(cambios.getNombre());
+            if (cambios.getStock() != null) existing.setStock(cambios.getStock());
+            return repo.save(existing);
+        });
+    }
+
+    public boolean eliminar(String id) {
+        if (repo.existsById(id)) {
+            repo.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 spring:
   data:
     mongodb:
-      uri: mongodb+srv://killuaryu1118_db_user:mrr34r3ZRUMTzfbK@cluster0.ve9xziv.mongodb.net/inventario_db?retryWrites=true&w=majority&appName=Cluster0
+      host: localhost
+      port: 27017
       database: inventario_db
   application:
     name: inventario-api


### PR DESCRIPTION
Añade persistencia real para productos (MongoDB): entidad, repositorio y servicio.
Convierte los endpoints de productos para usar la persistencia (CRUD).
Implementa notificaciones en tiempo real para movimientos vía STOMP/SockJS publicando en /topic/movimientos.
Mejora la API de movimientos:
Nuevo DTO de request [MovimientoReq](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) con validaciones (@NotBlank, @Min(1)).
Controlador usa @Valid MovimientoReq y publica notificaciones tipadas ([MovimientoNotification](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Se permite también el rol ADMIN para crear movimientos.
Cambios auxiliares:
[requests.http](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) y [.rest-client.env.json](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) con ejemplos y flujo de login/creación de movimientos (para pruebas con REST Client o curl).
Configuración WebSocket (endpoint /ws, broker simple).
Compilación verificada: build Maven OK (BUILD SUCCESS).